### PR TITLE
Feat - Enforce engine strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
-  "name": "@khanacademy/flow-to-ts",
-  "version": "0.5.2",
+  "name": "@simplyinsured/flow-to-ts",
+  "version": "0.5.3",
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": "16.x"
+  },
+  "engineStrict": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/khan/flow-to-ts"
+    "url": "https://github.com/simplyinsured/flow-to-ts"
   },
   "main": "dist/convert.js",
   "bin": {


### PR DESCRIPTION
This package only supports up to node v16 due to SSL errors that were patched in more recent versions of node.

```
❯ npm run build

> @khanacademy/flow-to-ts@0.5.2 build
> webpack build

Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
node:internal/crypto/hash:69
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/Users/dev/flow-to-ts/node_modules/webpack/lib/util/createHash.js:144:18)
    at BulkUpdateDecorator.update (/Users/dev/flow-to-ts/node_modules/webpack/lib/util/createHash.js:46:50)
    at RawSource.updateHash (/Users/dev/flow-to-ts/node_modules/webpack-sources/lib/RawSource.js:64:8)
    at NormalModule._initBuildHash (/Users/dev/flow-to-ts/node_modules/webpack/lib/NormalModule.js:829:17)
    at handleParseResult (/Users/dev/flow-to-ts/node_modules/webpack/lib/NormalModule.js:894:10)
    at /Users/dev/flow-to-ts/node_modules/webpack/lib/NormalModule.js:985:4
    at processResult (/Users/dev/flow-to-ts/node_modules/webpack/lib/NormalModule.js:716:11)
    at /Users/dev/flow-to-ts/node_modules/webpack/lib/NormalModule.js:768:5 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```